### PR TITLE
BugFix: Configured AsyncIOMotor to use the bot's event loop

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -77,7 +77,7 @@ class ModmailBot(commands.Bot):
             "cogs.modmail",
             "cogs.plugins",
             "cogs.utility",
-            "cogs.custom",
+            "cogs.general",
         ]
         self._connected = asyncio.Event()
         self.start_time = datetime.utcnow()

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -35,8 +35,8 @@ custom_statuses: typing.Dict[discord.ActivityType, typing.List[str]] = {
 logger = getLogger(__name__)
 
 
-class CodersSystem(commands.Cog):
-    """A cog for handling all custom stuff for Coder's System."""
+class General(commands.Cog):
+    """A cog for handling all general events and commands"""
 
     def __init__(self, bot: ModmailBot):
         self.bot = bot
@@ -82,4 +82,4 @@ class CodersSystem(commands.Cog):
 
 
 def setup(bot: ModmailBot):
-    bot.add_cog(CodersSystem(bot))
+    bot.add_cog(General(bot))

--- a/core/clients.py
+++ b/core/clients.py
@@ -385,7 +385,7 @@ class MongoDBClient(ApiClient):
                 raise RuntimeError
 
         try:
-            db = AsyncIOMotorClient(mongo_uri).modmail_bot
+            db = AsyncIOMotorClient(mongo_uri, io_loop=bot.loop).modmail_bot
         except ConfigurationError as e:
             logger.critical(
                 "Your MongoDB CONNECTION_URI might be copied wrong, try re-copying from the source again. "

--- a/core/config.py
+++ b/core/config.py
@@ -145,7 +145,7 @@ class ConfigManager:
         "enable_eval": True,
         # github access token for private repositories
         "github_token": None,
-        "disable_autoupdates": False,
+        "disable_autoupdates": True,
         "disable_updates": False,
         # Logging
         "log_level": "INFO",


### PR DESCRIPTION
By default, the `AsyncIOMotorClient` uses it's own event loop for doing tasks. But during bot startup, sometimes database connections fail due to the coroutines being run on 2 different event loops. I made it so that the database uses the bot's event loop, which will result in the stoppage of those task failure errors.

Here's some extra stuff I did:
- Renamed `cogs.custom` to `cogs.general`
- Disabled Auto updates (they can get annoying sometimes, and not needed till Discord makes a breaking change)

> Note: I would have not created this pull request with only these 2 commits, but this `AsyncIOMotorClient` issue is crucial, and can lead to the bot not starting up. So I did this as soon as possible.